### PR TITLE
Update to BuckleScript 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "bs-platform": "^1.8.1",
+    "bs-platform": "^3.0.0",
     "snabbdom": "^0.6.9",
     "http-server": "^0.10.0",
     "rollup": "^0.43.0",

--- a/src/snabbdom_base.ml
+++ b/src/snabbdom_base.ml
@@ -88,7 +88,7 @@ let attr key (value:string) = VNode.set_in_data [|"attrs"; key|] value
 
 (* Class module *)
 external module_class : snabbdom_module = "default" [@@bs.module "snabbdom/modules/class"]
-let class_name key = VNode.set_in_data [|"class"; key|] Js.true_
+let class_name key = VNode.set_in_data [|"class"; key|] true
 
 (* Style module *)
 external module_style : snabbdom_module = "default" [@@bs.module "snabbdom/modules/style"]


### PR DESCRIPTION
The `Js.true_` symbol no longer is defined.