### PR TITLE
Update BuckleScript to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "bs-platform": "^3.0.0",
+    "bs-platform": "^4.0.0",
     "snabbdom": "^0.6.9",
     "http-server": "^0.10.0",
     "rollup": "^0.43.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "bs-platform": "^1.8.1",
+    "bs-platform": "^3.0.0",
     "snabbdom": "^0.6.9",
     "http-server": "^0.10.0",
     "rollup": "^0.43.0",

--- a/src/snabbdom_base.ml
+++ b/src/snabbdom_base.ml
@@ -88,7 +88,7 @@ let attr key (value:string) = VNode.set_in_data [|"attrs"; key|] value
 
 (* Class module *)
 external module_class : snabbdom_module = "default" [@@bs.module "snabbdom/modules/class"]
-let class_name key = VNode.set_in_data [|"class"; key|] Js.true_
+let class_name key = VNode.set_in_data [|"class"; key|] true
 
 (* Style module *)
 external module_style : snabbdom_module = "default" [@@bs.module "snabbdom/modules/style"]

--- a/src/snabbdom_data.ml
+++ b/src/snabbdom_data.ml
@@ -2,9 +2,10 @@
 type t
 
 type data_val
-external to_data_val : 'a -> data_val = "%identity"
 
-let raw_empty : unit -> t = [%bs.raw{|function() { return {} } |}]
+external to_data_val : 'a -> data_val = "%identity"
+external raw_empty : unit -> t = "" [@@bs.obj]
+
 let raw_set_in_path : t -> string array -> data_val -> t = [%bs.raw{|
 function(data, path, value){
     var base = data || {};


### PR DESCRIPTION
This pull request fixes two issues:

1. BuckleScript now uses the native boolean values
2. There are changes that break currying of raw functions that take less arguments than declared.